### PR TITLE
Add Requires PHP to readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Contributors: bracketspace, Kubitomakita
 Tags: cron, wp cron, cron jobs, manager, cron manager, crontrol
 Requires at least: 3.6
+Requires PHP: 5.3
 Tested up to: 6.0
 Stable tag: 2.5.0
 License: GPLv2


### PR DESCRIPTION
https://wordpress.org/plugins/developers/readme-validator/ told me to do so.

https://github.com/BracketSpace/Advanced-Cron-Manager/blob/b1244a53f6545331c74738c2868809f6f8986562/phpcs.xml#L34
